### PR TITLE
fix(Annotation): Fix annotation so PHPStan won't complain

### DIFF
--- a/code/pages/ListingPage.php
+++ b/code/pages/ListingPage.php
@@ -49,9 +49,6 @@ class ListingPage extends Page {
 
 	private static $icon = 'listingpage/images/listingpage.png';
     
-	/**
-	 * @return FieldSet
-	 */
 	public function getCMSFields() {
 		$fields = parent::getCMSFields();
 		/* @var FieldSet $fields */


### PR DESCRIPTION
Fix annotation so PHPStan won't complain with "Call to method removeByName() on an unknown class FieldSet." on subclassed listing pages